### PR TITLE
feat: support the match the pre tag with html attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ if (config.total_time) {
 if (config.symbols || config.time || config.total_symbols || config.total_time) {
   hexo.extend.filter.register('after_post_render', data => {
     let { content } = data;
-    if (config.exclude_codeblock) content = content.replace(/<pre>.*?<\/pre>/g, '');
+    if (config.exclude_codeblock) content = content.replace(/<pre\b[^>]*>[\s\S]*?<\/pre>/g, '');
     data.length = stripHTML(content).replace(/\r?\n|\r/g, '').replace(/\s+/g, '').length;
   }, 0);
 }


### PR DESCRIPTION
NexT the last version is `8.17.1` now.
the`<pre>` html tag will be `<pre class="line-numbers language-bash" data-language="bash">`.
It means `pre` will append the html attribute, `exclude_codeblock` config need to match the pre tag with html attribute 